### PR TITLE
Couple improvements and fixes

### DIFF
--- a/backend/softwarepassport/app.py
+++ b/backend/softwarepassport/app.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 import uvicorn
@@ -67,7 +66,6 @@ def list_all_repositories(db: Session = Depends(get_db)):
     repos = Project.all(db)
     for r in repos:
         r.status = AuditLog.last_status(r.url, db)
-        r.scancode_report = json.loads(r.scancode_report)
     return repos
 
 

--- a/backend/softwarepassport/models.py
+++ b/backend/softwarepassport/models.py
@@ -12,7 +12,7 @@ import requests
 from reuse import lint
 from reuse.project import Project as ReuseProject
 from scancode.cli import run_scan
-from sqlalchemy import Boolean, Column, DateTime, Enum, Integer, String, desc
+from sqlalchemy import Boolean, Column, DateTime, Enum, Integer, String, desc, types
 from sqlalchemy.orm import Session
 
 from .config import settings
@@ -34,6 +34,16 @@ class State(enum.Enum):
     SCANCODE_END = 8
 
 
+class ScancodeReport(types.TypeDecorator):
+    impl = types.String
+    cache_ok = True
+
+    def process_result_value(self, val, dialect):
+        if val:
+            return json.loads(val)
+        return val
+
+
 class Project(Base):
     __tablename__ = "projects"
 
@@ -41,7 +51,7 @@ class Project(Base):
     hash = Column(String)
     reuse_compliant = Column(Boolean, default=False)
     reuse_report = Column(String, default=None)
-    scancode_report = Column(String, default=None)
+    scancode_report = Column(ScancodeReport, default=None)
     sawroom_tag = Column(String, index=True, default=None)
     fabric_tag = Column(String, index=True, default=None)
     ethereum_tag = Column(String, index=True, default=None)

--- a/backend/softwarepassport/models.py
+++ b/backend/softwarepassport/models.py
@@ -164,7 +164,7 @@ class Project(Base):
             if force:
                 L.debug("Force scanning project %s", self.url)
                 self.scancode(db)
-            elif not not self.scancode_report:
+            elif not self.scancode_report:
                 self.scancode(db)
             else:
                 self.__log(db, State.SCANCODE_START)

--- a/backend/softwarepassport/models.py
+++ b/backend/softwarepassport/models.py
@@ -147,7 +147,7 @@ class Project(Base):
                 continue
         self.__log(db, State.BLOCKCHAIN_END)
 
-    def scan(self, db: Session):
+    def scan(self, db: Session, force: bool):
         L.debug("Scanning project %s", self.url)
         existing = self.clone(db)
         if existing:
@@ -161,7 +161,10 @@ class Project(Base):
             else:
                 self.__log(db, State.BLOCKCHAIN_START)
                 self.__log(db, State.BLOCKCHAIN_END)
-            if not self.scancode_report:
+            if force:
+                L.debug("Force scanning project %s", self.url)
+                self.scancode(db)
+            elif not not self.scancode_report:
                 self.scancode(db)
             else:
                 self.__log(db, State.SCANCODE_START)


### PR DESCRIPTION
* Properly (I think) handle the conversion of `scancode_report` to JSON through a custom type
* Allow force scanning of repos (`scancode`)

Tested changes on my local instance at http://65.109.11.42:8004/repositories with the same dataset that I got from the Dyne instance, and only the things related to `blockchain` fail.  Example log:

```
[2022-07-06 07:08:09,714: WARNING/MainProcess] --- Logging error ---
[2022-07-06 07:08:09,715: WARNING/MainProcess] Traceback (most recent call last):
[2022-07-06 07:08:09,716: WARNING/MainProcess]   File "/usr/src/app/softwarepassport/models.py", line 143, in blockchain
    setattr(self, tag, r.json()[param])
[2022-07-06 07:08:09,716: WARNING/MainProcess] KeyError: 'txId'
[2022-07-06 07:08:09,716: WARNING/MainProcess]
During handling of the above exception, another exception occurred:
[2022-07-06 07:08:09,716: WARNING/MainProcess] Traceback (most recent call last):
[2022-07-06 07:08:09,716: WARNING/MainProcess]   File "/usr/local/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
[2022-07-06 07:08:09,716: WARNING/MainProcess]   File "/usr/local/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
[2022-07-06 07:08:09,717: WARNING/MainProcess]   File "/usr/local/lib/python3.10/site-packages/celery/utils/log.py", line 146, in format
    msg = super().format(record)
[2022-07-06 07:08:09,717: WARNING/MainProcess]   File "/usr/local/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
[2022-07-06 07:08:09,717: WARNING/MainProcess]   File "/usr/local/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
[2022-07-06 07:08:09,717: WARNING/MainProcess] TypeError: not all arguments converted during string formatting
[2022-07-06 07:08:09,717: WARNING/MainProcess] Call stack:
[2022-07-06 07:08:09,718: WARNING/MainProcess]   File "/usr/local/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
[2022-07-06 07:08:09,718: WARNING/MainProcess]   File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
[2022-07-06 07:08:09,718: WARNING/MainProcess]   File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 83, in _worker
    work_item.run()
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/site-packages/celery/concurrency/base.py", line 29, in apply_target
    ret = target(*args, **kwargs)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 649, in fast_trace_task
    R, I, T, Rstr = tasks[task].__trace__(
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/local/lib/python3.10/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/src/app/softwarepassport/app.py", line 105, in scan_task
    repo.scan(db, force)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/src/app/softwarepassport/models.py", line 160, in scan
    self.blockchain(db)
[2022-07-06 07:08:09,719: WARNING/MainProcess]   File "/usr/src/app/softwarepassport/models.py", line 146, in blockchain
    L.exception("Failed to post to blockchain", e)
[2022-07-06 07:08:09,719: WARNING/MainProcess] Message: 'Failed to post to blockchain'
Arguments: (KeyError('txId'),)
```